### PR TITLE
Duplicate call of self.lobby_addr.do_send(Disconnect { id: self.id, room_id: self.room });

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,7 +180,6 @@ impl WsConn {
         ctx.run_interval(HEARTBEAT_INTERVAL, |act, ctx| {
             if Instant::now().duration_since(act.hb) > CLIENT_TIMEOUT {
                 println!("Disconnecting failed heartbeat");
-                act.lobby_addr.do_send(Disconnect { id: act.id, room_id: act.room });
                 ctx.stop();
                 return;
             }
@@ -191,7 +190,7 @@ impl WsConn {
 }
 ```
 
-all that we do here is ping the client, and wait for a response on an interval. If the response doesn't come, the socket died; send a Disconnect and stop the client.
+all that we do here is ping the client, and wait for a response on an interval. If the response doesn't come, the socket died; stop the client. This triggers the `stopping()` function we defined earlier to be called, such that we disconnect from the lobby.
 
 ### handling WS messages
 
@@ -545,6 +544,3 @@ and boom! Our whole app now shares a single lobby. Here's everything we wrote:
 All in actix web, using actors! To test the client, I'd use a simple websocket for either [chrome](https://chrome.google.com/webstore/detail/simple-websocket-client/pfdhoblngboilpfeibdedpjgfnlcodoo?hl=en) or [firefox](https://addons.mozilla.org/en-US/firefox/addon/simple-websocket-client/). Open multiple tabs and send whispers or broadcasts in differnt lobbies!
 
 Happy WebSocketing!
-
-
-

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,13 +1,12 @@
-use actix::{fut, ActorContext, WrapFuture, ContextFutureSpawner, ActorFuture};
-use crate::messages::{Disconnect, Connect, WsMessage, ClientActorMessage};
-use crate::lobby::Lobby; 
+use crate::lobby::Lobby;
+use crate::messages::{ClientActorMessage, Connect, Disconnect, WsMessage};
+use actix::{fut, ActorContext, ActorFuture, ContextFutureSpawner, WrapFuture};
 use actix::{Actor, Addr, Running, StreamHandler};
 use actix::{AsyncContext, Handler};
 use actix_web_actors::ws;
 use actix_web_actors::ws::Message::Text;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
-
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -55,7 +54,10 @@ impl Actor for WsConn {
     }
 
     fn stopping(&mut self, _: &mut Self::Context) -> Running {
-        self.lobby_addr.do_send(Disconnect { id: self.id, room_id: self.room });
+        self.lobby_addr.do_send(Disconnect {
+            id: self.id,
+            room_id: self.room,
+        });
         Running::Stop
     }
 }
@@ -65,7 +67,6 @@ impl WsConn {
         ctx.run_interval(HEARTBEAT_INTERVAL, |act, ctx| {
             if Instant::now().duration_since(act.hb) > CLIENT_TIMEOUT {
                 println!("Disconnecting failed heartbeat");
-                act.lobby_addr.do_send(Disconnect { id: act.id, room_id: act.room });
                 ctx.stop();
                 return;
             }
@@ -97,9 +98,9 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsConn {
             Ok(Text(s)) => self.lobby_addr.do_send(ClientActorMessage {
                 id: self.id,
                 msg: s,
-                room_id: self.room
+                room_id: self.room,
             }),
-            
+
             Err(e) => panic!(e),
         }
     }


### PR DESCRIPTION
It is unnecessary to call act.lobby_addr.do_send(Disconnect { id: act.id, room_id: act.room }); here, because the ctx.stop(); will cause the actor to enter the stopping state. In that case the body of the stopping() function is run, which already sends a Disconnect message:

```
fn stopping(&mut self, _: &mut Self::Context) -> Running {
        self.lobby_addr.do_send(Disconnect { id: self.id, room_id: self.room });
        Running::Stop
    }
```